### PR TITLE
Add Angular as a bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,9 @@
   "description": "Virtual Scroll for AngularJS ngRepeat directive",
   "homepage": "http://kamilkp.github.io/angular-vs-repeat",
   "main": "dist/angular-vs-repeat.min.js",
+  "dependencies": {
+    "angular": ">= 1.2.0"
+  },
   "keywords": [
     "angularjs",
     "javascript",


### PR DESCRIPTION
If you are using a tool such as https://github.com/ck86/main-bower-files for bundling bower assets, `angular-vs-repeat` will be bundled before `angular`.

I have added the dependency of `"angular": ">= 1.2.0"` since `1.2.16` is used for developing/testing this directive: https://github.com/vend/angular-vs-repeat/blob/fb114d5d135a138eddeeb5cce8e9d18301218210/lib/angular.js

---

![](https://media.giphy.com/media/ORSNZOcDZ6hsQ/giphy.gif)